### PR TITLE
feat: use repo .labrador.yaml config file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,6 +29,9 @@ runs:
         GHACTION_LABRADOR_DOCKER_REF: ${{ github.action_ref }}
       run: download-labrador.sh
 
+    - name: Checkout repository code
+      uses: actions/checkout@v3
+
     - name: Run Labrador
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,9 @@ runs:
   using: 'composite'
   steps:
 
+    - name: Checkout repository code
+      uses: actions/checkout@v3
+
     - name: "Add this action's path to executable path"
       shell: bash
       # This is required for the action to find the shell scripts.
@@ -28,9 +31,6 @@ runs:
       env:
         GHACTION_LABRADOR_DOCKER_REF: ${{ github.action_ref }}
       run: download-labrador.sh
-
-    - name: Checkout repository code
-      uses: actions/checkout@v3
 
     - name: Run Labrador
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -2,9 +2,9 @@
 name: 'Labrador Action'
 description: 'Fetch and load values as environment variables'
 inputs:
-  ssm-path-prefix:
-    description: 'SSM Parameter Store base path to recursively fetch values from'
-    required: true
+  aws-ssm-parameters:
+    description: 'SSM Parameter Store paths to fetch values from.'
+    required: false
 
 branding:
   color: yellow
@@ -32,5 +32,5 @@ runs:
     - name: Run Labrador
       shell: bash
       env:
-        GHACTION_LABRADOR_AWS_PS: ${{ inputs.ssm-path-prefix }}
+        GHACTION_LABRADOR_AWS_PS: ${{ inputs.aws-ssm-parameters }}
       run: run-labrador.sh

--- a/scripts/download-labrador.sh
+++ b/scripts/download-labrador.sh
@@ -1,23 +1,29 @@
 #!/bin/bash
 
+# Image is a constant.
 image_repo="ghcr.io/divergentcodes/labrador"
 
-# Determine Docker image tag.
+# If ref is undefined, default to tag=latest.
 if [ -z "$GHACTION_LABRADOR_DOCKER_REF" ]; then
-    echo "No docker image tag defined in env var: GHACTION_LABRADOR_DOCKER_REF"
-    echo "If running in Github Actions, {{ github.action_ref }} might be undefined."
-    exit 1
-fi
+    # If running in Github Actions, {{ github.action_ref }} might be undefined.
+    echo "The Github Action version ref is empty."
+    echo "Using default Docker image tag: latest"
+    GHACTION_LABRADOR_DOCKER_REF="latest"
 
-if echo "$GHACTION_LABRADOR_DOCKER_REF" | grep -qe "^v[0-9]\+"; then
-    echo "Using Docker image $image_repo:$GHACTION_LABRADOR_DOCKER_REF"
+# If ref starts with v[0-9]+, use tag=version.
+elif echo "$GHACTION_LABRADOR_DOCKER_REF" | grep -qe "^v[0-9]\+"; then
+    echo "Using Docker image version tag: $GHACTION_LABRADOR_DOCKER_REF"
+
+# If tag doesn't start with v[0-9], default to tag=latest.
 else
-    echo "Invalid Docker image tag: $image_repo:$GHACTION_LABRADOR_DOCKER_REF"
-    exit 1
+    echo "The Github Action version ref is not a version tag: $GHACTION_LABRADOR_DOCKER_REF"
+    echo "Using default Docker image tag: latest"
+    GHACTION_LABRADOR_DOCKER_REF="latest"
 fi
 
 # Pull and extract Labrador.
-image_name="ghcr.io/divergentcodes/labrador:$GHACTION_LABRADOR_DOCKER_REF"
+image_name="$image_repo:$GHACTION_LABRADOR_DOCKER_REF"
+echo "Pulling Docker image $image_name"
 docker pull $image_name
 
 container_id=$(docker create $image_name)

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 
-# Determine AWS SSM Parameter Store path.
-if [ -z $GHACTION_LABRADOR_AWS_PS ]; then
-    echo "No AWS SSM Parameter Store path defined in env var: GHACTION_LABRADOR_AWS_PS"
-    exit 1
-fi
-
-# Determine outfile.
+# Determine outfile. Use local file for development,
+# and env file in Github Actions.
 if [ -n $GITHUB_ENV ]; then
     GHACTION_LABRADOR_OUTFILE="$GITHUB_ENV"
 else
@@ -17,5 +12,4 @@ fi
 # Run Labrador.
 ./labrador fetch \
     --verbose \
-    --out-file "$GHACTION_LABRADOR_OUTFILE" \
-    --aws-ps "$GHACTION_LABRADOR_AWS_PS"
+    --out-file "$GHACTION_LABRADOR_OUTFILE"

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -12,4 +12,4 @@ fi
 # Run Labrador.
 ./labrador fetch \
     --verbose \
-    --out-file "$GHACTION_LABRADOR_OUTFILE"
+    --outfile "$GHACTION_LABRADOR_OUTFILE"


### PR DESCRIPTION
- Use the calling repository's `.labrador.yaml` config file.
- Pull `latest` Docker image if no version tag is specified to ease action development.