### PR TITLE
feat: allow alternative config file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,11 @@
 name: 'Labrador Action'
 description: 'Fetch and load values as environment variables'
 inputs:
+  config:
+    description: 'Specify an alternative config file in the repo.'
+    required: false
   aws-ssm-parameters:
-    description: 'SSM Parameter Store paths to fetch values from.'
+    description: 'AWS SSM Parameter Store paths to fetch values from.'
     required: false
 
 branding:
@@ -14,12 +17,13 @@ runs:
   using: 'composite'
   steps:
 
+      # This is required to find the .labrador.yaml config file.
     - name: Checkout repository code
       uses: actions/checkout@v3
 
+      # This is required for the action to find the shell scripts.
     - name: "Add this action's path to executable path"
       shell: bash
-      # This is required for the action to find the shell scripts.
       run: |
         echo "${{ github.action_path }}" >> $GITHUB_PATH
         echo "${{ github.action_path }}/scripts" >> $GITHUB_PATH
@@ -35,5 +39,6 @@ runs:
     - name: Run Labrador
       shell: bash
       env:
+        GHACTION_LABRADOR_CONFIG_FILE: ${{ inputs.config }}
         GHACTION_LABRADOR_AWS_PS: ${{ inputs.aws-ssm-parameters }}
       run: run-labrador.sh

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -9,7 +9,14 @@ else
     GHACTION_LABRADOR_OUTFILE=./labrador-outfile.txt
 fi
 
+# Assemble optional CLI args.
+OPTIONAL_ARGS=""
+if [ -n $GHACTION_LABRADOR_CONFIG_FILE ]; then
+    OPTIONAL_ARGS=" --config $GHACTION_LABRADOR_CONFIG_FILE "
+fi
+
 # Run Labrador.
 ./labrador fetch \
     --verbose \
-    --outfile "$GHACTION_LABRADOR_OUTFILE"
+    --outfile "$GHACTION_LABRADOR_OUTFILE" \
+    $OPTIONAL_ARGS

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -11,7 +11,8 @@ fi
 
 # Assemble optional CLI args.
 OPTIONAL_ARGS=""
-if [ -n $GHACTION_LABRADOR_CONFIG_FILE ]; then
+if [ -n "$GHACTION_LABRADOR_CONFIG_FILE" ]; then
+    echo "Using alternate config file: $GHACTION_LABRADOR_CONFIG_FILE"
     OPTIONAL_ARGS=" --config $GHACTION_LABRADOR_CONFIG_FILE "
 fi
 
@@ -19,4 +20,4 @@ fi
 ./labrador fetch \
     --verbose \
     --outfile "$GHACTION_LABRADOR_OUTFILE" \
-    $OPTIONAL_ARGS
+    $OPTIONAL_ARGS ;

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -17,5 +17,5 @@ if [ -n "$GHACTION_LABRADOR_CONFIG_FILE" ]; then
 fi
 
 # Run Labrador.
-./labrador fetch \
-    --verbose --outfile "$GHACTION_LABRADOR_OUTFILE" $OPTIONAL_ARGS
+echo "./labrador fetch --verbose --outfile $GHACTION_LABRADOR_OUTFILE $OPTIONAL_ARGS"
+./labrador fetch --verbose --outfile "$GHACTION_LABRADOR_OUTFILE" $OPTIONAL_ARGS

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -18,6 +18,4 @@ fi
 
 # Run Labrador.
 ./labrador fetch \
-    --verbose \
-    --outfile "$GHACTION_LABRADOR_OUTFILE" \
-    $OPTIONAL_ARGS ;
+    --verbose --outfile "$GHACTION_LABRADOR_OUTFILE" $OPTIONAL_ARGS


### PR DESCRIPTION
Allow specifying an alternative configuration file with `inputs.config`.