### PR TITLE
feat: multiple AWS params in single input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,7 @@ inputs:
   config:
     description: 'Specify an alternative config file in the repo.'
     required: false
-  aws-ssm-parameters:
+  aws-ssm-parameter:
     description: 'AWS SSM Parameter Store paths to fetch values from.'
     required: false
 
@@ -40,5 +40,5 @@ runs:
       shell: bash
       env:
         GHACTION_LABRADOR_CONFIG_FILE: ${{ inputs.config }}
-        GHACTION_LABRADOR_AWS_PS: ${{ inputs.aws-ssm-parameters }}
+        GHACTION_LABRADOR_AWS_SSM_PARAM: ${{ inputs.aws-ssm-parameter }}
       run: run-labrador.sh

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -17,7 +17,10 @@ if [ -n "$GHACTION_LABRADOR_CONFIG_FILE" ]; then
 fi
 
 if [ -n "$GHACTION_LABRADOR_AWS_SSM_PARAM" ]; then
-    echo "Received AWS SSM Parameters to fetch: $GHACTION_LABRADOR_AWS_SSM_PARAM"
+    echo "Received AWS SSM Parameters to fetch:"
+    while IFS= read -r resource; do
+        echo "... $resource ..."
+    done <<< "$GHACTION_LABRADOR_AWS_SSM_PARAM"
 fi
 
 # Run Labrador.

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -16,6 +16,10 @@ if [ -n "$GHACTION_LABRADOR_CONFIG_FILE" ]; then
     OPTIONAL_ARGS=" --config $GHACTION_LABRADOR_CONFIG_FILE "
 fi
 
+if [ -n "$GHACTION_LABRADOR_AWS_SSM_PARAM" ]; then
+    echo "Received AWS SSM Parameters to fetch: $GHACTION_LABRADOR_AWS_SSM_PARAM"
+fi
+
 # Run Labrador.
 echo "./labrador fetch --verbose --outfile $GHACTION_LABRADOR_OUTFILE $OPTIONAL_ARGS"
 ./labrador fetch --verbose --outfile "$GHACTION_LABRADOR_OUTFILE" $OPTIONAL_ARGS

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -9,18 +9,21 @@ else
     GHACTION_LABRADOR_OUTFILE=./labrador-outfile.txt
 fi
 
-# Assemble optional CLI args.
 OPTIONAL_ARGS=""
+
+# --config
 if [ -n "$GHACTION_LABRADOR_CONFIG_FILE" ]; then
     echo "Using alternate config file: $GHACTION_LABRADOR_CONFIG_FILE"
     OPTIONAL_ARGS=" --config $GHACTION_LABRADOR_CONFIG_FILE "
 fi
 
+# --aws-param
+# Loop over multi-line variables to read multiple resources from input.
 if [ -n "$GHACTION_LABRADOR_AWS_SSM_PARAM" ]; then
     echo "Received AWS SSM Parameters to fetch:"
     while IFS= read -r resource; do
         if [[ -n $(echo $resource | tr -d '[:space:]') ]]; then
-            echo "    ...$resource..."
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --aws-param $resource "
         fi
     done <<< "$GHACTION_LABRADOR_AWS_SSM_PARAM"
 fi

--- a/scripts/run-labrador.sh
+++ b/scripts/run-labrador.sh
@@ -19,7 +19,9 @@ fi
 if [ -n "$GHACTION_LABRADOR_AWS_SSM_PARAM" ]; then
     echo "Received AWS SSM Parameters to fetch:"
     while IFS= read -r resource; do
-        echo "... $resource ..."
+        if [[ -n $(echo $resource | tr -d '[:space:]') ]]; then
+            echo "    ...$resource..."
+        fi
     done <<< "$GHACTION_LABRADOR_AWS_SSM_PARAM"
 fi
 


### PR DESCRIPTION
By passing each desired AWS SSM parameter as a line in a single multi-line variable `input.aws-ssm-parameter`, the action can loop over the variable and apply each one as a CLI argument.